### PR TITLE
Add RSS and Atom feeds for events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,6 +15,12 @@ class EventsController < ApplicationController
     end
 
     @events = @scope.order('id DESC').load
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def show
@@ -39,6 +45,12 @@ class EventsController < ApplicationController
     end
 
     @events = @events.load
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def user

--- a/app/views/events/index.atom.builder
+++ b/app/views/events/index.atom.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title @title
+  xml.subtitle 'Recent GitHub events indexed by ecosyste.ms'
+  xml.id events_url(event_type: params[:event_type])
+  xml.link href: events_url(event_type: params[:event_type])
+  xml.link href: events_url(event_type: params[:event_type], format: :atom), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@events.first&.created_at || Time.current).iso8601)
+
+  @events.each do |event|
+    xml.entry do
+      xml.title "#{event.event_type} in #{event.repository}"
+      xml.id event_url(event.repository, anchor: event.id)
+      xml.link href: (event.html_url || event_url(event.repository))
+      xml.updated event.created_at.iso8601
+      xml.summary "#{event.actor} - #{event.event_type}"
+    end
+  end
+end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, events_url(event_type: params[:event_type], format: :rss), title: "Recent Events RSS") %>
+  <%= auto_discovery_link_tag(:atom, events_url(event_type: params[:event_type], format: :atom), title: "Recent Events Atom") %>
+<% end %>
+
 <div class="px-4 pt-2 mb-5 text-center">
   <h1 class="display-5 fw-bold">
     Recent <%= params[:event_type].try(:titleize) || 'Event' %>s

--- a/app/views/events/index.rss.builder
+++ b/app/views/events/index.rss.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title @title
+    xml.description 'Recent GitHub events indexed by ecosyste.ms'
+    xml.link events_url(event_type: params[:event_type])
+    xml.language 'en'
+
+    @events.each do |event|
+      xml.item do
+        xml.title "#{event.event_type} in #{event.repository}"
+        xml.description "#{event.actor} - #{event.event_type}"
+        xml.link event.html_url || event_url(event.repository)
+        xml.guid event_url(event.repository, anchor: event.id), isPermaLink: false
+        xml.pubDate event.created_at.rfc2822
+      end
+    end
+  end
+end

--- a/app/views/events/show.atom.builder
+++ b/app/views/events/show.atom.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title @title
+  xml.subtitle "Recent GitHub events for #{@repository}"
+  xml.id event_url(@repository, year: @year.year, event_type: params[:event_type])
+  xml.link href: event_url(@repository, year: @year.year, event_type: params[:event_type])
+  xml.link href: event_url(@repository, year: @year.year, event_type: params[:event_type], format: :atom), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@events.first&.created_at || Time.current).iso8601)
+
+  @events.each do |event|
+    xml.entry do
+      xml.title "#{event.event_type} by #{event.actor}"
+      xml.id event_url(@repository, anchor: event.id)
+      xml.link href: (event.html_url || event_url(@repository))
+      xml.updated event.created_at.iso8601
+      xml.summary "#{event.actor} - #{event.event_type}"
+    end
+  end
+end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, event_url(@repository, year: @year.year, event_type: params[:event_type], format: :rss), title: "#{@repository} Events RSS") %>
+  <%= auto_discovery_link_tag(:atom, event_url(@repository, year: @year.year, event_type: params[:event_type], format: :atom), title: "#{@repository} Events Atom") %>
+<% end %>
+
 <div class="px-4 pt-2 mb-5 text-center">
   <h1 class="display-5 fw-bold">
     <%= link_to "https://github.com/#{@repository.split('/').first}", target: :_blank do %>

--- a/app/views/events/show.rss.builder
+++ b/app/views/events/show.rss.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title @title
+    xml.description "Recent GitHub events for #{@repository}"
+    xml.link event_url(@repository, year: @year.year, event_type: params[:event_type])
+    xml.language 'en'
+
+    @events.each do |event|
+      xml.item do
+        xml.title "#{event.event_type} by #{event.actor}"
+        xml.description "#{event.actor} - #{event.event_type}"
+        xml.link event.html_url || event_url(@repository)
+        xml.guid event_url(@repository, anchor: event.id), isPermaLink: false
+        xml.pubDate event.created_at.rfc2822
+      end
+    end
+  end
+end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -32,6 +32,59 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_template 'events/index'
   end
 
+
+  test 'index provides RSS and Atom auto discovery links' do
+    get events_url
+
+    assert_response :success
+    assert_select 'link[rel="alternate"][type="application/rss+xml"][href=?]', events_url(format: :rss)
+    assert_select 'link[rel="alternate"][type="application/atom+xml"][href=?]', events_url(format: :atom)
+  end
+
+  test 'renders index RSS feed' do
+    get events_url(format: :rss)
+
+    assert_response :success
+    assert_equal 'application/rss+xml', response.media_type
+    assert_includes response.body, '<rss'
+    assert_includes response.body, @event.repository
+  end
+
+  test 'renders index Atom feed' do
+    get events_url(format: :atom)
+
+    assert_response :success
+    assert_equal 'application/atom+xml', response.media_type
+    assert_includes response.body, '<feed'
+    assert_includes response.body, @event.repository
+  end
+
+  test 'repository page provides RSS and Atom auto discovery links' do
+    get event_path("Zahabul/humescores")
+
+    assert_response :success
+    assert_select 'link[rel="alternate"][type="application/rss+xml"]'
+    assert_select 'link[rel="alternate"][type="application/atom+xml"]'
+  end
+
+  test 'renders repository RSS feed' do
+    get event_path("Zahabul/humescores", format: :rss)
+
+    assert_response :success
+    assert_equal 'application/rss+xml', response.media_type
+    assert_includes response.body, '<rss'
+    assert_includes response.body, @event.repository
+  end
+
+  test 'renders repository Atom feed' do
+    get event_path("Zahabul/humescores", format: :atom)
+
+    assert_response :success
+    assert_equal 'application/atom+xml', response.media_type
+    assert_includes response.body, '<feed'
+    assert_includes response.body, @event.repository
+  end
+
   test 'renders show' do
     get event_path("Zahabul/humescores")
     assert_response :success


### PR DESCRIPTION
Refs #213

## Summary
- adds RSS and Atom feed responses for the global events list
- adds RSS and Atom feed responses for repository-specific event timelines
- adds feed auto-discovery links in the HTML head for both list pages
- covers discovery links and feed responses in controller tests

## Validation
- `ruby -c app/controllers/events_controller.rb`
- `ruby -c app/views/events/index.rss.builder`
- `ruby -c app/views/events/index.atom.builder`
- `ruby -c app/views/events/show.rss.builder`
- `ruby -c app/views/events/show.atom.builder`
- `ruby -c test/controllers/events_controller_test.rb`
- `git diff --check`

Full controller test execution is locally blocked because the lockfile requires Bundler 4.0.10 and this system Ruby cannot activate it.